### PR TITLE
fix: make repo helm repository parameters truly optional

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,8 +8,13 @@ aws eks \
 
 # Helm Dependency Update
 # helm dependency update ${DEPLOY_CHART_PATH:-helm/}
-helm repo add magic ${REPO} --username ${REPO_USERNAME} --password ${REPO_PASSWORD} --pass-credentials
-helm repo update
+if [ -n "$REPO" ]; then
+    echo "Adding helm repository: $REPO"
+    helm repo add magic ${REPO} --username ${REPO_USERNAME} --password ${REPO_PASSWORD} --pass-credentials
+    helm repo update
+else
+    echo "No helm repository specified, using local chart only"
+fi
 
 UPGRADE_COMMAND="helm upgrade --install"
 


### PR DESCRIPTION
## Problem
Currently the action unconditionally attempts to add a helm repository even when using local charts, causing authentication errors when repo parameters are not provided.

## Solution
- Add conditional check for REPO variable before executing helm repo commands
- Log appropriate message based on whether external repo is configured
- Maintain full backward compatibility with existing workflows

## Benefits
- Enables deployment of local charts without dummy repo configuration
- Eliminates authentication errors for local-only deployments
- Improves action usability and matches documented optional parameters
- No breaking changes for existing users
